### PR TITLE
Add desc for more usability

### DIFF
--- a/lib/fluent/plugin/out_chatwork.rb
+++ b/lib/fluent/plugin/out_chatwork.rb
@@ -14,10 +14,13 @@ module Fluent::Plugin
 
     desc "Secret API Token"
     config_param :api_token, :string
+
     desc "Send message to this room."
     config_param :room_id  , :string
+
     desc "Message content. Supported erb format and newline character."
     config_param :message  , :string
+
     desc "Switch non-buffered/buffered plugin"
     config_param :buffered, :bool, default: false
 

--- a/lib/fluent/plugin/out_chatwork.rb
+++ b/lib/fluent/plugin/out_chatwork.rb
@@ -12,10 +12,13 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
+    desc "Secret API Token"
     config_param :api_token, :string
+    desc "Send message to this room."
     config_param :room_id  , :string
+    desc "Message content. Supported erb format and newline character."
     config_param :message  , :string
-    # Switch non-buffered/buffered plugin
+    desc "Switch non-buffered/buffered plugin"
     config_param :buffered, :bool, default: false
 
     config_section :buffer do


### PR DESCRIPTION
How about add `desc` method to show config parameters' descriptions?

In v0.14, we can obtain config parameters descriptions with the following command:

```bash
% bundle exec fluent-plugin-config-format --format=(markdown|txt|json) output chatwork
```