### PR TITLE
Resolved. timeout error at `gem update --system`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
 cache: bundler
 bundler_args: "--jobs=2"
 before_install:
-  - travis_retry gem update --system || travis_retry gem update --system 2.7.8
   - travis_retry gem install bundler --no-document || travis_retry gem install bundler --no-document -v 1.17.3
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
c.f. https://travis-ci.org/sue445/fluent-plugin-chatwork/builds/624561888

```
$ travis_retry gem update --system || travis_retry gem update --system 2.7.8
Updating rubygems-update
Fetching: rubygems-update-3.1.0.gem (100%)
Successfully installed rubygems-update-3.1.0
Installing RubyGems 3.1.0
  Successfully built RubyGem
  Name: bundler
  Version: 2.1.0.pre.3
  File: bundler-2.1.0.pre.3.gem
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.3.8/bin/bundle
Overwrite the executable? [yN]  
```