### PR TITLE
Fix CI on Ruby < 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,9 @@ if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.6.0")
   # faraday v2.0.0+ requires Ruby 2.6.0+
   gem "faraday", "< 2.0.0"
 end
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.3.0")
+  # multipart-post uses `Object.deprecate_constant`, but this available since Ruby 2.3.0+
+  # https://github.com/socketry/multipart-post/blob/v2.2.0/lib/multipart/post/parts.rb#L152
+  gem "multipart-post", "< 2.2.0"
+end


### PR DESCRIPTION
multipart-post uses `Object.deprecate_constant`, but this available since Ruby 2.3.0+

https://github.com/socketry/multipart-post/blob/v2.2.0/lib/multipart/post/parts.rb#L152

Close #38